### PR TITLE
feat(schema): 复飞 leg canonical schema v1 + 三张问卷模板 (Issue #3)

### DIFF
--- a/docs/schemas/missed_approach_leg_v1.md
+++ b/docs/schemas/missed_approach_leg_v1.md
@@ -1,0 +1,326 @@
+# Missed-Approach Leg Canonical Schema v1
+
+**Status**: draft for Issue #3
+**Scope**: canonical JSON + three surface questionnaire forms + composite scoring rules
+**Cycle context**: FAA CIFP 2604 (effective 16 APR 2026)
+
+## 1. Purpose
+
+This document freezes the canonical leg-level structure that every ABCDE method must
+project into, regardless of its internal representation (flat fields for OCR+rules, JSON
+from LLM, per-question aggregation for VLM QA, etc.). The same structure is produced by
+the CIFP→proxy-GT pipeline (Issue #4) from raw ARINC 424 records.
+
+Three surface questionnaire forms are defined on top of the canonical structure:
+
+- **Canonical JSON** — target final form consumed by the evaluator
+- **QA prompt bundle** — Method C's multi-turn question set (per leg, per question type)
+- **Structured form template** — Method E's form-fill questionnaire
+
+All three surfaces project to the same canonical JSON; the evaluator only sees
+canonical JSON.
+
+## 2. Top-level envelope
+
+```json
+{
+  "chart_id": "KCOE_L06",
+  "procedure": {
+    "airport": "KCOE",
+    "approach_ident": "L06",
+    "chart_name": "ILS OR LOC RWY 06"
+  },
+  "missed_approach": {
+    "leg_count": { "status": "present", "value": 4 },
+    "legs": [ ... ]
+  }
+}
+```
+
+- `chart_id` is the dataset primary key (`{airport}_{approach_ident}`)
+- `procedure.*` fields are data keys copied from the committed manifest; not method outputs
+- `missed_approach.leg_count` is a **procedure-level** question; `missed_approach.legs` is the ordered sequence of per-leg answer bundles
+
+## 3. Status enum
+
+Every answered field carries a `status`:
+
+| Status | Meaning |
+|---|---|
+| `present` | Chart publishes (or implies via standard convention) a definite value; value field is populated |
+| `not_applicable` | This field has no meaning for this leg type (e.g., hold_params on a CA leg) |
+| `not_observable` | Regulation allows chart to omit this + chart does not show it. See Issue #6 regulatory matrix |
+| `unknown` | Method could not determine the value (with or without confidence) |
+
+Inferable-by-convention values (1-min hold, standard LOC-aligned hold inbound course,
+LEFT turn implied by preceding "climbing left turn" wording) **are `present`**, not
+`not_observable`; reading comprehension expected.
+
+## 4. Per-leg answer schema
+
+Each leg = `{ leg_index: int, answers: { 6 keys } }`.
+
+### 4.1 Q_terminator — ARINC 2-letter path terminator
+
+Issue #26 requires exact ARINC code output, no semantic merging.
+
+Value domain:
+`CA CF CI CR DF FA FM HA HF HM IF RF TF VA VD VI VM VR AF CD FC FD VC PI` (24 codes)
+
+Typical missed-approach distribution (from `missed_approach_extracted/_summary.json` on
+the 100-sample set): HM, CA, DF, TF, CF, VI, FA. Others permitted by spec but rare.
+
+### 4.2 Q1_fix_ident — the fix this leg references
+
+The fix associated with this leg's geometry. Role implicit from `Q_terminator`:
+
+| Terminator | Fix role |
+|---|---|
+| CF / DF / TF / AF | Terminator fix |
+| FA / FC / FD / FM | Origin fix |
+| HA / HF / HM | Hold fix |
+| IF | Initial fix |
+| CA / VA / VD / VI / VM / VR / CD / CI / CR / VC / RF / PI | no fix reference; status = `not_applicable` |
+
+Value = ident string (5 chars max, e.g., `"COE"`, `"MUDRE"`, `"RW06"`) or `null`.
+
+### 4.3 Q2_altitude_constraint — **composite**
+
+Entire answer scores as one atom: `desc` + `altitude_ft` (+ optional `altitude_2_ft` for
+BETWEEN) **must all match** or it's `contradicted`.
+
+```json
+{
+  "status": "present",
+  "value": {
+    "desc": "AT_OR_ABOVE",
+    "altitude_ft": 2900,
+    "altitude_2_ft": null
+  }
+}
+```
+
+`desc` domain: `AT`, `AT_OR_ABOVE`, `AT_OR_BELOW`, `BETWEEN`.
+
+ARINC 5.29 raw → canonical mapping:
+
+| 5.29 raw | canonical `desc` |
+|---|---|
+| blank, `@` | `AT` |
+| `+` | `AT_OR_ABOVE` |
+| `-`, `V` | `AT_OR_BELOW` |
+| `B` | `BETWEEN` (uses both `altitude_ft` and `altitude_2_ft`) |
+| `G`, `H`, `I`, `J`, `X`, `Y`, `C` | `AT` (glideslope-specific; rare in missed-approach legs) |
+
+`altitude_ft` is integer feet. `FL180` → `18000`.
+
+Method outputs `{ "status": "not_applicable", "value": null }` when leg has no altitude
+constraint at all (rare; most missed-approach legs have at least a climb-to target).
+
+### 4.4 Q3_turn — turn direction during this leg
+
+| Leg shape | Expected answer |
+|---|---|
+| Straight leg (CA, VA, TF without curvature, IF) | `not_applicable` |
+| Turning leg (DF, CF with preceding turn text, FA with turn text, RF) | `"LEFT"` or `"RIGHT"` |
+| Hold leg (HA/HF/HM) | `not_applicable`; hold turn direction lives in Q5_hold_params |
+
+### 4.5 Q4_course_or_radial — course / heading / radial reference for this leg
+
+Discriminated union on `type`:
+
+```jsonc
+// Variant A — magnetic course / track
+{ "type": "course_deg", "course_deg": 51 }
+
+// Variant B — navaid radial reference
+{ "type": "navaid_radial", "navaid": "COE", "radial_deg": 350, "direction": "outbound" }
+// direction ∈ { "outbound", "inbound" }
+
+// Variant C — direct (DF legs; terminator fix fully determines geometry)
+{ "type": "direct" }
+```
+
+`course_deg` is float, 1 decimal, range `[0.0, 359.9]`. Magnetic by default; a true-course
+flag is recorded in extraction-schema but not in canonical output.
+
+Hold legs: `not_applicable`; hold's inbound course lives in Q5_hold_params.
+
+### 4.6 Q5_hold_params — **composite**, only for HA / HF / HM
+
+All four sub-fields scored jointly:
+
+```json
+{
+  "status": "present",
+  "value": {
+    "inbound_course_deg": 51,
+    "leg_time_min": 1.0,
+    "leg_distance_nm": null,
+    "turn": "LEFT"
+  }
+}
+```
+
+- `inbound_course_deg` float, magnetic
+- Exactly ONE of `leg_time_min` (typical) / `leg_distance_nm` (RNAV distance-based) is
+  non-null; the other is null
+- `turn` ∈ `{ "LEFT", "RIGHT" }`
+
+For non-hold legs: `{ "status": "not_applicable", "value": null }`.
+
+## 5. Worked example — KCOE_L06 (complete canonical JSON)
+
+The chart, CIFP raw records, and extraction output live in
+`data/v2604_100/missed_approach_review/KCOE_L06/`.
+
+```json
+{
+  "chart_id": "KCOE_L06",
+  "procedure": {
+    "airport": "KCOE",
+    "approach_ident": "L06",
+    "chart_name": "ILS OR LOC RWY 06"
+  },
+  "missed_approach": {
+    "leg_count": { "status": "present", "value": 4 },
+    "legs": [
+      {
+        "leg_index": 1,
+        "answers": {
+          "Q_terminator": { "status": "present", "value": "CA" },
+          "Q1_fix_ident": { "status": "not_applicable", "value": null },
+          "Q2_altitude_constraint": {
+            "status": "present",
+            "value": { "desc": "AT_OR_ABOVE", "altitude_ft": 2900, "altitude_2_ft": null }
+          },
+          "Q3_turn": { "status": "not_applicable", "value": null },
+          "Q4_course_or_radial": {
+            "status": "present",
+            "value": { "type": "course_deg", "course_deg": 51 }
+          },
+          "Q5_hold_params": { "status": "not_applicable", "value": null }
+        }
+      },
+      {
+        "leg_index": 2,
+        "answers": {
+          "Q_terminator": { "status": "present", "value": "FA" },
+          "Q1_fix_ident": { "status": "present", "value": "COE" },
+          "Q2_altitude_constraint": {
+            "status": "present",
+            "value": { "desc": "AT_OR_ABOVE", "altitude_ft": 6000, "altitude_2_ft": null }
+          },
+          "Q3_turn": { "status": "present", "value": "LEFT" },
+          "Q4_course_or_radial": {
+            "status": "present",
+            "value": { "type": "navaid_radial", "navaid": "COE", "radial_deg": 350, "direction": "outbound" }
+          },
+          "Q5_hold_params": { "status": "not_applicable", "value": null }
+        }
+      },
+      {
+        "leg_index": 3,
+        "answers": {
+          "Q_terminator": { "status": "present", "value": "CF" },
+          "Q1_fix_ident": { "status": "present", "value": "COE" },
+          "Q2_altitude_constraint": {
+            "status": "present",
+            "value": { "desc": "AT_OR_ABOVE", "altitude_ft": 6500, "altitude_2_ft": null }
+          },
+          "Q3_turn": { "status": "present", "value": "LEFT" },
+          "Q4_course_or_radial": {
+            "status": "present",
+            "value": { "type": "navaid_radial", "navaid": "COE", "radial_deg": 350, "direction": "inbound" }
+          },
+          "Q5_hold_params": { "status": "not_applicable", "value": null }
+        }
+      },
+      {
+        "leg_index": 4,
+        "answers": {
+          "Q_terminator": { "status": "present", "value": "HM" },
+          "Q1_fix_ident": { "status": "present", "value": "COE" },
+          "Q2_altitude_constraint": {
+            "status": "present",
+            "value": { "desc": "AT_OR_ABOVE", "altitude_ft": 6500, "altitude_2_ft": null }
+          },
+          "Q3_turn": { "status": "not_applicable", "value": null },
+          "Q4_course_or_radial": { "status": "not_applicable", "value": null },
+          "Q5_hold_params": {
+            "status": "present",
+            "value": {
+              "inbound_course_deg": 51,
+              "leg_time_min": 1.0,
+              "leg_distance_nm": null,
+              "turn": "LEFT"
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+## 6. Extraction-schema vs canonical-schema
+
+Two schemas coexist in the project:
+
+| Aspect | Extraction schema | Canonical (this doc) |
+|---|---|---|
+| Where | `data/v2604_100/missed_approach_extracted/{chart_id}.json` | `data/v2604_100/missed_approach/{chart_id}.json` |
+| Producer | `scripts/extract_missed_approach.py` (Issue #4) | projection from extraction schema via deterministic mapper |
+| Purpose | Preserve all ARINC 424 per-leg fields + `raw_record` for evidence | Evaluator-facing; aligned 1:1 with method outputs |
+| Field count per leg | ~22 (ARINC fields minus hygiene) | 6 composite questions + leg_index |
+| Includes `raw_record`? | Yes | No |
+| Includes path_terminator? | Yes (`path_terminator`) | Yes (`Q_terminator`) |
+| Includes FAA-synthesized altitudes flagged? | Yes (raw) | As `status: not_observable` when applicable (per Issue #6 matrix) |
+
+The projection rules live in the companion script `scripts/project_canonical.py` (to be
+added alongside Issue #4). Projection is deterministic; no human judgment.
+
+## 7. Questionnaire surface forms
+
+Method-specific surfaces, all targeting the same canonical JSON:
+
+- **Canonical JSON form** (this file's main subject) — final form
+- **QA prompt bundle** — `prompts/path_c_qa_v2/` — 7 files: `q0_leg_count.txt`,
+  `q_terminator.txt`, `q1_fix_ident.txt`, `q2_altitude_constraint.txt`, `q3_turn.txt`,
+  `q4_course_or_radial.txt`, `q5_hold_params.txt`
+- **Structured form template** — `prompts/path_e_v2/structured_form_template.txt` —
+  single file; VLM fills slots
+
+Both prompt bundles are sources of truth for their respective methods; any change here
+that affects the prompts must update the prompts.
+
+## 8. Composite scoring rules (for Issue #9 scorer)
+
+Fields that score as one atom (desc + value must all match):
+
+- `Q2_altitude_constraint` — `desc` + `altitude_ft` + `altitude_2_ft`
+- `Q4_course_or_radial` — `type` + all sub-fields for that variant
+- `Q5_hold_params` — `inbound_course_deg` + (`leg_time_min` or `leg_distance_nm`) + `turn`
+
+Leg-level end-to-end correctness (for Issue #14 per-leg F1):
+- Hit: every Q has status match AND (for `present` status) value match
+- Partial: ≥ 1 Q correct, ≥ 1 Q wrong
+- Contradicted: ≥ 1 Q value mismatch under `present` status
+- Missing: leg absent from method output where GT expects one
+- Extra: leg present in method output where GT has none
+
+Numeric tolerances (to be finalized in error_taxonomy.md during Issue #9):
+
+| Field | Tolerance |
+|---|---|
+| `altitude_ft` | exact |
+| `course_deg`, `radial_deg`, `inbound_course_deg` | ±1.0° |
+| `leg_time_min` | exact (values are always 0.5-min multiples in practice) |
+| `leg_distance_nm` | ±0.1 NM |
+
+## 9. Open points
+
+- Issue #6 regulatory matrix determines which per-field cases trigger `not_observable`
+- Issue #9 scorer may revise numeric tolerances based on pilot data
+- Issue #14 will finalize whether `Q_terminator` shares the same F1 bucket as
+  other fields or is reported as its own score

--- a/prompts/path_c_qa_v2/q0_leg_count.txt
+++ b/prompts/path_c_qa_v2/q0_leg_count.txt
@@ -1,0 +1,25 @@
+TASK: From this instrument approach chart, count the number of missed-approach legs.
+
+Inspect the MISSED APPROACH text block and the profile-strip icons. Missed approach
+is the part AFTER the missed approach point (MAP), typically at the runway threshold
+or a specific fix flagged with "M" in ARINC coding. A leg is one "phase" of the
+climb / turn / navigate / hold sequence a pilot flies after executing missed approach.
+
+Example text:
+  "Climb to 2900 then climbing left turn to 6000 on COE R-350 outbound then
+   climbing left turn to 6500 on COE R-350 inbound to COE VOR/DME and hold."
+
+Legs here (count = 4):
+  1. Straight climb to 2900
+  2. Climbing left turn on R-350 outbound to 6000
+  3. Climbing left turn on R-350 inbound to COE at 6500
+  4. Hold at COE
+
+OUTPUT (single JSON object):
+
+{ "status": "<present|not_observable|unknown>", "value": <integer | null> }
+
+Rules:
+- If you can count legs from the chart → status=present, value=count.
+- If the chart gives no missed-approach instructions at all (rare) → status=not_observable, value=null.
+- If uncertain → status=unknown, value=null. "unknown" is a valid answer; do not guess.

--- a/prompts/path_c_qa_v2/q1_fix_ident.txt
+++ b/prompts/path_c_qa_v2/q1_fix_ident.txt
@@ -1,0 +1,34 @@
+TASK: For missed-approach leg <LEG_INDEX>, identify the fix this leg references.
+
+The role of the fix depends on the leg's path terminator:
+
+  Terminator  | Fix role
+  ------------+-----------------------------
+  CF DF TF AF | Terminator fix (leg ends here)
+  FA FC FD FM | Origin fix (leg starts here)
+  HA HF HM    | Hold fix (aircraft holds here)
+  IF          | Initial fix
+  CA VA VI    | No fix reference
+  VM VR VD    | No fix reference
+  CD CI CR VC | No fix reference
+  RF PI       | Special (see radius-to-fix / procedure-intercept semantics)
+
+Read the fix identifier (waypoint or navaid ident) from:
+- MISSED APPROACH text block (e.g., "direct COE", "hold at MUDRE")
+- Profile strip labels (e.g., COE, TIYOS, RW06)
+- Plan-view waypoint labels
+
+OUTPUT (single JSON object):
+
+{
+  "status": "<present|not_applicable|not_observable|unknown>",
+  "value": "<ident|null>"
+}
+
+Rules:
+- Leg type has a fix (per above table) and chart shows it → status=present, value=ident.
+- Leg type has NO fix → status=not_applicable, value=null.
+- Leg type should have a fix but chart omits a required ident → status=not_observable, value=null.
+- You see something but cannot read it → status=unknown, value=null.
+
+Idents are typically 5 characters or fewer (e.g., "COE", "MUDRE", "RW06", "BRA").

--- a/prompts/path_c_qa_v2/q2_altitude_constraint.txt
+++ b/prompts/path_c_qa_v2/q2_altitude_constraint.txt
@@ -1,0 +1,36 @@
+TASK: For missed-approach leg <LEG_INDEX>, identify its altitude constraint (composite answer).
+
+Descriptors (exactly one):
+
+  AT           — cross the altitude exactly (rare on climbing legs)
+  AT_OR_ABOVE  — at or above altitude (typical for climb-to-altitude segments)
+  AT_OR_BELOW  — at or below altitude
+  BETWEEN      — between altitude_ft (upper bound) and altitude_2_ft (lower bound)
+
+Chart typography cues:
+- "Climb to N" or "to N" → typically AT_OR_ABOVE N
+- "at N" or explicit single line → AT N
+- "N / M" stacked (upper / lower) → BETWEEN with upper=N, lower=M
+- Number with a crossbar ABOVE → AT_OR_ABOVE
+- Number with a crossbar BELOW → AT_OR_BELOW
+- Number with crossbars both above and below → AT (exact)
+
+OUTPUT (single JSON object):
+
+{
+  "status": "<present|not_applicable|not_observable|unknown>",
+  "value": {
+    "desc": "<AT|AT_OR_ABOVE|AT_OR_BELOW|BETWEEN>",
+    "altitude_ft": <int>,
+    "altitude_2_ft": <int | null>
+  } | null
+}
+
+Scoring note: this is a COMPOSITE field. desc, altitude_ft, and altitude_2_ft are
+all compared as one atom — any one wrong makes the whole answer contradicted.
+
+Rules:
+- altitude_2_ft is non-null ONLY for BETWEEN; null otherwise.
+- Leg has no altitude constraint at all (rare; check carefully) → status=not_applicable, value=null.
+- All visible and readable → status=present.
+- You see a constraint but cannot read a number → status=unknown, value=null.

--- a/prompts/path_c_qa_v2/q3_turn.txt
+++ b/prompts/path_c_qa_v2/q3_turn.txt
@@ -1,0 +1,27 @@
+TASK: For missed-approach leg <LEG_INDEX>, identify the turn direction during this leg.
+
+Chart cues:
+- "climbing left turn" / "climbing right turn" phrases in MISSED APPROACH text block
+- Plan-view arrow heads indicating turn direction on the missed-approach track
+- Profile-view curved arrows with directional labeling
+
+Which legs can have a turn answer:
+- CA / VA / VI / TF / IF legs are typically straight → not_applicable
+- DF / CF legs with preceding "turn" wording → LEFT or RIGHT
+- FA legs with explicit "climbing turn" → LEFT or RIGHT
+- RF legs always turn; direction determined by arc center position
+- Hold legs (HA / HF / HM): hold turn direction belongs to Q5_hold_params, NOT here
+  → status=not_applicable for Q3
+
+OUTPUT (single JSON object):
+
+{
+  "status": "<present|not_applicable|not_observable|unknown>",
+  "value": "<LEFT|RIGHT|null>"
+}
+
+Rules:
+- Straight leg → not_applicable, value=null.
+- Hold leg → not_applicable, value=null (Q5 carries hold turn).
+- Turning leg and direction readable → present, value=LEFT or RIGHT.
+- Turning leg but direction ambiguous → unknown, value=null.

--- a/prompts/path_c_qa_v2/q4_course_or_radial.txt
+++ b/prompts/path_c_qa_v2/q4_course_or_radial.txt
@@ -1,0 +1,43 @@
+TASK: For missed-approach leg <LEG_INDEX>, identify the course / heading / radial that
+governs the ground track of this leg.
+
+Three answer variants (discriminated by "type"):
+
+VARIANT A — magnetic course (CA / VA / TF / CF without explicit radial reference):
+  { "type": "course_deg", "course_deg": <0.0 .. 359.9> }
+
+VARIANT B — navaid radial (FA / CF when text says "on <navaid> R-NNN outbound/inbound"):
+  {
+    "type": "navaid_radial",
+    "navaid": "<ident>",
+    "radial_deg": <0.0 .. 359.9>,
+    "direction": "outbound" | "inbound"
+  }
+
+VARIANT C — direct (DF legs where no course is specified):
+  { "type": "direct" }
+
+Chart cues:
+- "Climb to N on heading <deg>" → course_deg (record the heading value)
+- "Climb to N, course <deg>" → course_deg
+- "On <navaid> R-NNN outbound/inbound to <fix>" → navaid_radial
+- "Direct <fix>" → direct
+- Hold legs do NOT populate Q4; their inbound course lives in Q5_hold_params
+
+OUTPUT (single JSON object):
+
+{
+  "status": "<present|not_applicable|not_observable|unknown>",
+  "value": <variant object | null>
+}
+
+Scoring note: COMPOSITE field. All sub-fields for the chosen variant compared as one atom.
+
+Rules:
+- Hold leg (HA/HF/HM) → not_applicable.
+- No course reference (very rare on non-hold legs) → not_applicable.
+- All visible → present, value=variant object.
+- Variant clear but a number unreadable → unknown, value=null.
+
+Units: all degrees are MAGNETIC by default. The schema does not carry a true-course flag;
+if the chart prints "T" suffix on a bearing, still record the numeric value here.

--- a/prompts/path_c_qa_v2/q5_hold_params.txt
+++ b/prompts/path_c_qa_v2/q5_hold_params.txt
@@ -1,0 +1,46 @@
+TASK: For missed-approach leg <LEG_INDEX>, if it is a hold leg (HA / HF / HM), identify
+the hold parameters (composite answer).
+
+Four sub-fields:
+
+  inbound_course_deg  : magnetic course flown TOWARDS the hold fix (0.0 .. 359.9)
+  leg_time_min        : time on each racetrack leg (typical: 1.0 min below 14000 ft,
+                        1.5 min above). Mutually exclusive with leg_distance_nm.
+  leg_distance_nm     : distance-based hold (RNAV); null if time-based.
+  turn                : "LEFT" or "RIGHT" — direction of racetrack turns
+
+Exactly ONE of leg_time_min / leg_distance_nm is non-null.
+
+Chart cues:
+- Racetrack (stadium) symbol near the hold fix on the plan view
+- "and hold" / "hold at <fix>" phrase in MISSED APPROACH text
+- Course labeled along the racetrack's inbound leg
+- Time / distance labeled near the racetrack (e.g., "1 min" or "4 NM")
+- Turn direction from the racetrack's curve orientation OR text
+  "left turns" / "right turns"
+
+Standard inferences (use when chart does not explicitly state — these are valid PRESENT
+answers, not not_observable):
+- Time-based hold: 1.0 min below 14000 ft, 1.5 min at or above
+- Turn direction: right turns unless chart shows otherwise
+
+OUTPUT (single JSON object):
+
+{
+  "status": "<present|not_applicable|not_observable|unknown>",
+  "value": {
+    "inbound_course_deg": <float | null>,
+    "leg_time_min": <float | null>,
+    "leg_distance_nm": <float | null>,
+    "turn": "<LEFT|RIGHT|null>"
+  } | null
+}
+
+Scoring note: COMPOSITE field. All four sub-fields compared as one atom.
+
+Rules:
+- Non-hold leg (CA/CF/DF/TF/FA/VI/etc.) → status=not_applicable, value=null.
+- Hold leg with explicit + inferable parameters → status=present, value populated.
+- Hold leg but a parameter cannot be determined even from standard conventions
+  → set that sub-field to null; keep status=present if other parameters resolved,
+  or status=unknown if too many are null.

--- a/prompts/path_c_qa_v2/q_terminator.txt
+++ b/prompts/path_c_qa_v2/q_terminator.txt
@@ -1,0 +1,38 @@
+TASK: For missed-approach leg <LEG_INDEX>, identify its ARINC 424 path terminator.
+
+ARINC 424 defines 24 path-terminator codes. The most common in FAA missed-approach
+procedures and their chart signatures:
+
+  CA  Course to Altitude         — climb on a magnetic course until reaching altitude
+  VA  Heading to Altitude        — climb on a magnetic heading until reaching altitude
+  FA  Fix to Altitude            — from a fix, fly a course and climb to altitude
+  DF  Direct to Fix              — fly directly to a named fix; path unspecified
+  CF  Course to Fix              — fly a specified course to a fix
+  TF  Track to Fix               — fly a straight track between two waypoints
+  HM  Hold to Manual termination — standard racetrack, pilot ends hold manually
+  HF  Hold to Fix                — one circuit of the racetrack then proceed
+  HA  Hold to Altitude           — hold until reaching a specified altitude
+  VI  Heading to Intercept       — fly heading until intercepting the next leg
+  RF  Radius to Fix              — constant-radius arc with specified center and radius
+
+Chart cues (non-exhaustive):
+- "Climb to N ft" with no fix mentioned → CA or VA
+- "From <fix> climb / fly to N" → FA
+- "Direct <fix>" / "climbing turn direct <fix>" → DF
+- "On <navaid> R-NNN outbound/inbound to <fix>" → CF (or FA if terminator is altitude)
+- "Hold at <fix>" with racetrack symbol → HM (standard), HA (until altitude), HF (one circuit)
+- Arc symbol with specified radius → RF
+
+OUTPUT (single JSON object):
+
+{ "status": "<present|not_observable|unknown>", "value": "<2-letter code | null>" }
+
+Value domain for a valid code (any one of):
+  CA CF CI CR DF FA FM HA HF HM IF RF TF VA VD VI VM VR AF CD FC FD VC PI
+
+Rules:
+- If you can determine the code from chart + standard ARINC semantics → status=present.
+- If chart is ambiguous between two codes (e.g., CA vs VA, both mean "climb to altitude"
+  but differ on track-vs-heading semantics that chart may not disambiguate) → return the
+  code you judge most likely + status=present. If truly unable to choose → status=unknown.
+- Do not guess; unknown is a valid answer.

--- a/prompts/path_e_v2/structured_form_template.txt
+++ b/prompts/path_e_v2/structured_form_template.txt
@@ -1,0 +1,68 @@
+=== Missed Approach Questionnaire ===
+
+Chart ID: ____________________
+
+Q0. Missed approach leg count:
+    value = _______
+    status = [ ] present  [ ] not_observable  [ ] unknown
+
+[For each leg i = 1..leg_count, fill in the block below once]
+
+=== Leg <i> ===
+
+Q_terminator  (ARINC 2-letter code, or "unknown"):
+  [ ] CA   [ ] CF   [ ] CI   [ ] CR   [ ] DF   [ ] FA   [ ] FM
+  [ ] HA   [ ] HF   [ ] HM   [ ] IF   [ ] RF   [ ] TF
+  [ ] VA   [ ] VD   [ ] VI   [ ] VM   [ ] VR
+  [ ] AF   [ ] CD   [ ] FC   [ ] FD   [ ] VC   [ ] PI
+  [ ] unknown
+  status = [ ] present  [ ] not_observable  [ ] unknown
+
+Q1. Fix ident (the fix this leg references):
+  [ ] not_applicable  (CA/VA/VI/VD/VM/VR/CD/CI/CR/VC/RF legs)
+  [ ] value: ident = _______________
+  [ ] not_observable
+  [ ] unknown
+
+Q2. Altitude constraint  (COMPOSITE — fill entire row):
+  [ ] not_applicable  (leg has no altitude constraint)
+  [ ] AT            _________ ft
+  [ ] AT_OR_ABOVE   _________ ft
+  [ ] AT_OR_BELOW   _________ ft
+  [ ] BETWEEN       upper _________ ft  AND  lower _________ ft
+  [ ] not_observable
+  [ ] unknown
+
+Q3. Turn direction during this leg:
+  [ ] not_applicable  (straight leg, or hold leg — hold turn lives in Q5)
+  [ ] LEFT
+  [ ] RIGHT
+  [ ] not_observable
+  [ ] unknown
+
+Q4. Course / radial reference  (COMPOSITE — pick one variant):
+  [ ] not_applicable  (hold leg; no course reference)
+  [ ] Variant A — course_deg = _________ (magnetic, 0.0-359.9)
+  [ ] Variant B — navaid_radial:
+        navaid    = _______________
+        radial_deg = _________
+        direction  = [ ] outbound  [ ] inbound
+  [ ] Variant C — direct  (DF legs; terminator fix fully determines geometry)
+  [ ] not_observable
+  [ ] unknown
+
+Q5. Hold parameters  (COMPOSITE — fill only for HA / HF / HM):
+  [ ] not_applicable  (non-hold leg)
+  [ ] hold leg:
+        inbound_course_deg = _________
+        leg_time_min       = _________  (mutually exclusive with leg_distance_nm)
+        leg_distance_nm    = _________
+        turn               = [ ] LEFT  [ ] RIGHT
+  [ ] not_observable
+  [ ] unknown
+
+=== End of Leg <i> ===
+
+[Repeat Leg block for each subsequent leg, up to leg_count]
+
+=== End of Questionnaire ===

--- a/schemas/missed_approach_leg.schema.json
+++ b/schemas/missed_approach_leg.schema.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/reshihihihi/faa-missed-approach-experiment/schemas/missed_approach_leg.schema.json",
+  "title": "FAA Missed-Approach Leg Canonical Questionnaire v1",
+  "description": "Canonical JSON schema for missed-approach leg-level extraction. Every ABCDE method output and the CIFP-derived proxy GT share this structure. See docs/schemas/missed_approach_leg_v1.md for design rationale.",
+  "type": "object",
+  "required": ["chart_id", "procedure", "missed_approach"],
+  "additionalProperties": false,
+  "properties": {
+    "chart_id": {
+      "type": "string",
+      "description": "Dataset primary key, format {airport}_{approach_ident}",
+      "pattern": "^[A-Z]{4}_[A-Z0-9\\-]+$"
+    },
+    "procedure": {
+      "type": "object",
+      "required": ["airport", "approach_ident", "chart_name"],
+      "additionalProperties": false,
+      "properties": {
+        "airport": { "type": "string", "pattern": "^[A-Z]{4}$" },
+        "approach_ident": { "type": "string" },
+        "chart_name": { "type": "string" }
+      }
+    },
+    "missed_approach": {
+      "type": "object",
+      "required": ["leg_count", "legs"],
+      "additionalProperties": false,
+      "properties": {
+        "leg_count": { "$ref": "#/$defs/answer_int" },
+        "legs": {
+          "type": "array",
+          "minItems": 0,
+          "items": { "$ref": "#/$defs/leg" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "status_enum": {
+      "type": "string",
+      "enum": ["present", "not_applicable", "not_observable", "unknown"]
+    },
+    "answer_int": {
+      "type": "object",
+      "required": ["status", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "status": { "$ref": "#/$defs/status_enum" },
+        "value": { "type": ["integer", "null"] }
+      }
+    },
+    "leg": {
+      "type": "object",
+      "required": ["leg_index", "answers"],
+      "additionalProperties": false,
+      "properties": {
+        "leg_index": { "type": "integer", "minimum": 1 },
+        "answers": {
+          "type": "object",
+          "required": [
+            "Q_terminator",
+            "Q1_fix_ident",
+            "Q2_altitude_constraint",
+            "Q3_turn",
+            "Q4_course_or_radial",
+            "Q5_hold_params"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "Q_terminator": { "$ref": "#/$defs/answer_terminator" },
+            "Q1_fix_ident": { "$ref": "#/$defs/answer_fix_ident" },
+            "Q2_altitude_constraint": { "$ref": "#/$defs/answer_altitude_constraint" },
+            "Q3_turn": { "$ref": "#/$defs/answer_turn" },
+            "Q4_course_or_radial": { "$ref": "#/$defs/answer_course_or_radial" },
+            "Q5_hold_params": { "$ref": "#/$defs/answer_hold_params" }
+          }
+        }
+      }
+    },
+    "answer_terminator": {
+      "type": "object",
+      "required": ["status", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "status": { "$ref": "#/$defs/status_enum" },
+        "value": {
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "string",
+              "enum": [
+                "CA", "CF", "CI", "CR", "DF", "FA", "FM",
+                "HA", "HF", "HM", "IF", "RF", "TF",
+                "VA", "VD", "VI", "VM", "VR",
+                "AF", "CD", "FC", "FD", "VC", "PI",
+                "unknown"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "answer_fix_ident": {
+      "type": "object",
+      "required": ["status", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "status": { "$ref": "#/$defs/status_enum" },
+        "value": {
+          "anyOf": [
+            { "type": "null" },
+            { "type": "string", "minLength": 1, "maxLength": 5 }
+          ]
+        }
+      }
+    },
+    "answer_altitude_constraint": {
+      "type": "object",
+      "required": ["status", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "status": { "$ref": "#/$defs/status_enum" },
+        "value": {
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "required": ["desc", "altitude_ft", "altitude_2_ft"],
+              "additionalProperties": false,
+              "properties": {
+                "desc": {
+                  "type": "string",
+                  "enum": ["AT", "AT_OR_ABOVE", "AT_OR_BELOW", "BETWEEN"]
+                },
+                "altitude_ft": { "type": ["integer", "null"] },
+                "altitude_2_ft": { "type": ["integer", "null"] }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "answer_turn": {
+      "type": "object",
+      "required": ["status", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "status": { "$ref": "#/$defs/status_enum" },
+        "value": {
+          "anyOf": [
+            { "type": "null" },
+            { "type": "string", "enum": ["LEFT", "RIGHT"] }
+          ]
+        }
+      }
+    },
+    "answer_course_or_radial": {
+      "type": "object",
+      "required": ["status", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "status": { "$ref": "#/$defs/status_enum" },
+        "value": {
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "required": ["type"],
+              "oneOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "type": { "const": "course_deg" },
+                    "course_deg": { "type": "number", "minimum": 0, "maximum": 359.9 }
+                  },
+                  "required": ["type", "course_deg"]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "type": { "const": "navaid_radial" },
+                    "navaid": { "type": "string", "minLength": 1, "maxLength": 5 },
+                    "radial_deg": { "type": "number", "minimum": 0, "maximum": 359.9 },
+                    "direction": { "type": "string", "enum": ["outbound", "inbound"] }
+                  },
+                  "required": ["type", "navaid", "radial_deg", "direction"]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "type": { "const": "direct" }
+                  },
+                  "required": ["type"]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "answer_hold_params": {
+      "type": "object",
+      "required": ["status", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "status": { "$ref": "#/$defs/status_enum" },
+        "value": {
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "required": ["inbound_course_deg", "leg_time_min", "leg_distance_nm", "turn"],
+              "additionalProperties": false,
+              "properties": {
+                "inbound_course_deg": { "type": ["number", "null"], "minimum": 0, "maximum": 359.9 },
+                "leg_time_min": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+                "leg_distance_nm": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+                "turn": {
+                  "anyOf": [
+                    { "type": "null" },
+                    { "type": "string", "enum": ["LEFT", "RIGHT"] }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

首次实现 Issue #3 扩展后的 canonical leg-level 问卷定义。包含 JSON Schema + 人读规范 + 三张问卷模板（canonical JSON / QA / 结构化表单）。

**Status**: DRAFT，等待 review。

## 包含的文件

- `schemas/missed_approach_leg.schema.json` — JSON Schema 2020-12
- `docs/schemas/missed_approach_leg_v1.md` — 人读规范（字段定义、chart-observability 原则、复合字段评分规则、KCOE_L06 完整样例）
- `prompts/path_c_qa_v2/` — Method C 的 7 个 QA prompt（Q0 leg count + Q1-Q5 + Q_terminator）
- `prompts/path_e_v2/structured_form_template.txt` — Method E 结构化表单模板

## 关键设计决议

基于对话整理：

1. **每 leg 6 个问题**：Q_terminator + Q1 fix_ident + Q2 altitude_constraint + Q3 turn + Q4 course_or_radial + Q5 hold_params
2. **复合字段作为原子评分**：altitude_constraint (desc+alt+alt2) / course_or_radial (type+variant fields) / hold_params (inbound+time_or_dist+turn) 任一 sub 错则整题错
3. **Path terminator 保留全部 24 种 ARINC 码**，不做语义分组归并 (#26)
4. **标准约定可推的值 status=present**（如 1 min hold / LOC-aligned 051° 等），不是 `not_observable`。"读懂航图" = 多源综合 + 领域推理，不只是 OCR
5. **`not_observable` 严格定义**：(法规允许不画) ∧ (图上未找到)。白名单由 #6 regulatory matrix 独立推进，不阻塞本 PR
6. **approach_ident 不是 method 输出**，只是数据键；manifest 承载
7. **extraction schema ≠ canonical schema**：extraction 保留所有 ARINC 字段 + raw_record 作 evidence；canonical 只装 6 题答案供评估器比较

## 验证

- JSON Schema 文件通过 `jsonschema` 包的 Draft 2020-12 schema check
- KCOE_L06 完整 canonical 样例（文中内嵌）通过 schema 实例校验

## 关联 issue

- **Closes conceptually**: Issue #3 原 scope（本 PR 把 #3 从"leg schema"扩展到"schema + 3 问卷"）
- **依赖**: Issue #26（path_terminator 独立子任务）—— Q_terminator 字段定义源自该 issue 的决议
- **被依赖**:
  - Issue #4（CIFP→proxy JSON）将把 `missed_approach_extracted/*.json` 投影到本 schema
  - Issue #9（audit scorer）实现本 schema 的评分逻辑
  - Issues #10/#11/#12（方法迁移）按本 schema 改造 A/B/C/D/E

## Open points (not blocking this PR)

- `not_observable` 白名单需要 Issue #6 完成法规矩阵后才能填实
- 数值容差（course_deg ±1°、leg_distance_nm ±0.1 NM）在 Issue #9 评分器 pilot 后确认
- `Q_terminator` 的 F1 是否和其他字段同列报告，由 Issue #14 决定

## Test plan

- [ ] 领域人读过 KCOE_L06 样例，确认 canonical JSON 正确表达该图复飞程序
- [ ] 过一张 RNAV 程序（如 KANP_RNV-A 或 KAVL_I17）的 canonical JSON，验证 schema 覆盖面
- [ ] QA prompts 给 VLM pilot 试跑（pilot 3 张图）
- [ ] 结构化表单给 VLM pilot 试跑，parser 把填好的表单转 canonical JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)
