### PR TITLE
chore(paper-v2): add NeurIPS E&D scaffold directories

### DIFF
--- a/benchmark_exports/derived/v2/README.md
+++ b/benchmark_exports/derived/v2/README.md
@@ -1,0 +1,29 @@
+# paper-v2 derived benchmark export namespace
+
+This directory is the intended read-only data entry point for paper-v2 experiments.
+
+All formal paper-v2 runners should read through `MANIFEST.json` and the files listed here rather than directly reading legacy paths, pilot outputs, or temporary annotation-platform internals.
+
+## Planned data artifacts
+
+- `MANIFEST.json` — version, source commits, source issues/PRs, split counts, checksums, schema version.
+- `sample_manifest.jsonl` — chart-level sample records and source paths.
+- `splits.json` — development / evaluation / probe split lock.
+- `field_targets.jsonl` — field-level target expansion for scoring.
+- `roi_manifest.jsonl` — ROI records with prelabel/human status.
+- `gold_ma_text.jsonl` — human-corrected missed-approach prose only.
+- `evidence_provenance.jsonl` — frozen evidence buckets.
+- `challenge_tags.jsonl` — frozen challenge tags.
+- `gold_observable_evidence.jsonl` — visible chart facts for oracle diagnostics.
+- `verification_counterfactuals.jsonl` — chart-to-424 verification cases.
+- `checksums.sha256` — file checksums for the derived export.
+- `source_views/` — generated source-view images and manifests.
+
+## Related issues
+
+- PV2-02: #35
+- PV2-04: #37
+- PV2-05: #38
+- PV2-06: #39
+- PV2-07: #40
+- PV2-12: #45

--- a/benchmark_exports/derived/v2/pilot10_manifest.jsonl
+++ b/benchmark_exports/derived/v2/pilot10_manifest.jsonl
@@ -1,0 +1,1 @@
+{"chart_id":"TBD","procedure_id":"TBD","split":"pilot10_dev","source_image":"TBD","canonical_target":"TBD","selection_reason":"ordinary / holding / ca_leg / multi_leg / ocr_hard / path_terminator_hard","excluded_from_formal_eval":true,"source_ref":"TBD"}

--- a/configs/paper_v2/README.md
+++ b/configs/paper_v2/README.md
@@ -1,0 +1,18 @@
+# paper-v2 configuration namespace
+
+This directory stores frozen configuration manifests for paper-v2 runs.
+
+Configuration files in this directory should be treated as part of the experiment freeze. If a model version, prompt file, parser policy, or rerun rule changes after evaluation begins, create a new run ID and update the relevant manifest rather than overwriting previous outputs.
+
+## Planned files
+
+- `model_config_manifest.json` — model/provider/version/temperature/top_p/max_tokens/OCR engine details.
+- `prompt_manifest.json` — prompt path, prompt hash, allowed inputs, forbidden inputs, and prompt version.
+- `parser_repair_policy.md` — fixed parser repair rules for malformed model outputs.
+- `d_sft_training_config.json` — D-SFT training configuration, if D-SFT is included.
+
+## Related issues
+
+- PV2-03: #36
+- PV2-13: #46
+- PV2-14: #47

--- a/configs/paper_v2/model_config_manifest.json
+++ b/configs/paper_v2/model_config_manifest.json
@@ -1,0 +1,26 @@
+{
+  "run_id": "pilot10_exp1_a1_b1_c3_v0",
+  "scope": "pilot-only",
+  "notes": "Fill all TBD values before running the pilot. Do not use this manifest for formal evaluation without re-freezing.",
+  "ocr": {
+    "applies_to": ["A1", "B1"],
+    "engine": "TBD",
+    "version": "TBD",
+    "settings": "TBD"
+  },
+  "llm": {
+    "applies_to": ["B1"],
+    "model": "TBD",
+    "temperature": 0,
+    "top_p": 1,
+    "max_tokens": "TBD"
+  },
+  "vlm": {
+    "applies_to": ["C3"],
+    "model": "TBD",
+    "temperature": 0,
+    "top_p": 1,
+    "max_tokens": "TBD",
+    "image_resolution_policy": "TBD"
+  }
+}

--- a/configs/paper_v2/parser_repair_policy.md
+++ b/configs/paper_v2/parser_repair_policy.md
@@ -1,0 +1,30 @@
+# Parser Repair Policy v0
+
+Scope: `pilot10_exp1_a1_b1_c3_v0` and future paper-v2 runs unless superseded.
+
+## Allowed repair
+
+- Remove markdown code fences.
+- Extract the first JSON object from surrounding explanatory text.
+- Remove explanatory text before or after JSON.
+- Normalize field-name casing where the mapping is unambiguous.
+- Normalize `unknown`, `not observable`, `cannot determine`, and equivalent phrases to the schema vocabulary.
+- Mark missing or malformed fields as `invalid` according to the schema, instead of filling answers.
+
+## Forbidden repair
+
+- Do not modify field values using canonical targets.
+- Do not use scorer results to repair predictions.
+- Do not manually fill `Q_terminator`.
+- Do not manually add missing legs.
+- Do not manually fill altitude, fix, turn, course/radial, or hold values.
+- Do not delete failed samples.
+- Do not convert wrong answers to `unknown` after scoring.
+
+## Parse failure handling
+
+- Preserve raw output.
+- Record `parse_error`.
+- Mark final output as `invalid`.
+- Include invalid outputs in scorer statistics.
+- Never silently drop samples.

--- a/configs/paper_v2/prompt_manifest.json
+++ b/configs/paper_v2/prompt_manifest.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "pilot10_exp1_a1_b1_c3_v0",
+  "scope": "pilot-only",
+  "prompts": [
+    {
+      "method_id": "B1",
+      "prompt_path": "prompts/paper_v2/b1_ocr_to_canonical_pilot10.md",
+      "prompt_hash": "TBD",
+      "inherits": ["issue #20 unknown/not_observable instruction"],
+      "allowed_inputs": ["full-chart OCR text", "OCR bbox/confidence if explicitly included"],
+      "forbidden_inputs": ["chart image", "gold_ma_prose", "canonical target", "expected value", "evidence provenance", "challenge tags", "field-to-leg target mapping"]
+    },
+    {
+      "method_id": "C3",
+      "prompt_path": "prompts/paper_v2/c3_questionnaire_pilot10.md",
+      "prompt_hash": "TBD",
+      "inherits": ["PR #28 structured questionnaire", "issue #20 unknown/not_observable instruction"],
+      "allowed_inputs": ["full chart image", "frozen questionnaire prompt/template"],
+      "forbidden_inputs": ["OCR text", "gold_ma_prose", "canonical target", "expected value", "evidence provenance", "challenge tags", "field-to-leg target mapping"]
+    }
+  ]
+}

--- a/docs/paper_v2/README.md
+++ b/docs/paper_v2/README.md
@@ -1,0 +1,27 @@
+# paper-v2 documentation namespace
+
+This directory contains the frozen planning, policies, and reviewer-facing documentation for the NeurIPS 2026 Evaluations & Datasets paper-v2 submission package.
+
+This namespace is intentionally separate from the existing first-round ABCDE experiment documentation. Existing issues and PRs remain the engineering foundation; paper-v2 documents define the submission-facing experiment registry, bias controls, artifact release plan, and paper reporting plan.
+
+## Planned files
+
+- `experiment_registry.md` — frozen experiment groups, methods, metrics, and table mapping.
+- `claim_evidence_table.md` — evaluative claims, supporting experiments, assumptions, and limits.
+- `analysis_plan.md` — analysis freeze before evaluation runs.
+- `split_policy.md` — development / evaluation / probe split usage policy.
+- `method_registry.md` — method IDs, allowed inputs, forbidden inputs, prompt/model hashes.
+- `no_leakage_policy.md` — input-packer and leakage-control policy.
+- `source_view_policy.md` — source-view generation and regenerated OCR policy.
+- `counterfactual_construction.md` — chart-to-424 counterfactual construction policy.
+- `statistical_reporting_policy.md` — bootstrap and paired-delta reporting policy.
+- `reproducibility_checklist.md` — final reproducibility checklist.
+
+## Related issues
+
+- PV2-00: #33
+- PV2-01: #34
+- PV2-02: #35
+- PV2-03: #36
+- PV2-14: #47
+- PV2-18: #51

--- a/docs/paper_v2/pilot10_exp1_a1_b1_c3_freeze.md
+++ b/docs/paper_v2/pilot10_exp1_a1_b1_c3_freeze.md
@@ -1,0 +1,538 @@
+# Pilot-10 Exp1 A1/B1/C3 参数冻结方案
+
+## 0. 定位
+
+本文件冻结 `paper_v2_pilot10_exp1_a1_b1_c3` 的 **pilot-only** 运行参数和可继承通用规则。
+
+本 pilot 只用于验证实验组 1 的最小流程是否可行：
+
+```text
+完整航图
+  -> A1 OCR+Rules
+  -> B1 OCR+LLM
+  -> C3 image->questionnaire->canonical JSON
+  -> parser / validator / scorer / no-leakage check
+```
+
+本 pilot 不作为正式论文主结果。如果根据 pilot 结果修改 prompt、parser、schema wrapper、scorer 或 input policy，正式实验必须重新冻结并重跑。
+
+## 1. 继承已有 issue / PR 的冻结要求
+
+本 pilot 继承以下已有 issue / PR 的设计，不在本文件中重新定义这些上位规范。
+
+| 项目 | 继承来源 | 本 pilot 中的用法 |
+|---|---|---|
+| canonical schema | PR #28 | 使用 leg-level canonical schema |
+| C3 questionnaire / structured form | PR #28 | 使用 questionnaire-style 输出并转 canonical JSON |
+| Q_terminator vocabulary | PR #28, issue #27 | 使用 24 种 ARINC code + `unknown` |
+| field status vocabulary | issue #7, PR #28 | 使用 `present / not_applicable / not_observable / unknown / invalid` |
+| proxy target 口径 | issue #3, issue #5, PR #29, PR #32 | target 只作为 scoring proxy，不作为绝对真值 |
+| formal300 / practice assets | PR #32 | pilot 样本优先从 formal300 之外的 practice/pilot assets 选取 |
+| unknown / not_observable prompt 原则 | issue #20 | B1 / C3 prompt 必须允许拒判 |
+| A1 / B1 / C3 方法大类 | issue #11, issue #12, issue #13 | 继承方法方向，本文件冻结本次 pilot 的具体运行边界 |
+
+> 注意：如果 PR #28 / #29 / #32 在本 pilot 运行时仍未合并，本 pilot 必须记录实际使用的 PR head commit。本 pilot 结果不进入正式论文主表；正式 eval 应在 v2 manifest 固化后重跑。
+
+## 2. 通用可继承冻结规则
+
+本节中的规则不只服务 pilot。后续 paper-v2 的实验组 1-7 应默认继承这些规则，除非显式升级版本并记录变更原因。
+
+### 2.1 Schema / scorer 通用规则
+
+所有方法输出必须投影到同一个 canonical schema：
+
+```text
+unit: chart / procedure
+structure: procedure -> legs -> Q_terminator + Q1-Q5
+schema_source: TBD, expected PR #28 commit d2c54172b31184f8c0deb74415f37c239d3e3eca
+schema_path: TBD, expected schemas/missed_approach_leg.schema.json
+```
+
+字段状态允许值：
+
+```text
+present
+not_applicable
+not_observable
+unknown
+invalid
+```
+
+`Q_terminator` 允许值：
+
+```text
+CA, CF, CI, CR, DF, FA, FM, HA, HF, HM, IF, RF,
+TF, VA, VD, VI, VM, VR, AF, CD, FC, FD, VC, PI,
+unknown
+```
+
+pilot 中暂定 scorer 规则：
+
+```text
+schema validation failure -> invalid
+unparseable model output -> invalid
+missing required leg / field -> missing / invalid, not silently dropped
+unknown / not_observable must be preserved, not coerced to null
+```
+
+如果 pilot 后修改 schema/scorer 口径，必须升级版本，例如：
+
+```text
+schema_policy_v0 -> schema_policy_v1
+scorer_policy_v0 -> scorer_policy_v1
+```
+
+### 2.2 Allowed / forbidden input 通用规则
+
+#### A1: OCR + Rules
+
+Allowed inputs:
+
+```text
+full chart image
+OCR text generated from the full chart image
+OCR bbox / confidence generated from the full chart image
+fixed Rules code
+```
+
+Forbidden inputs:
+
+```text
+canonical target
+expected value
+gold_ma_prose
+evidence provenance
+challenge tags
+field-to-leg target mapping
+Q_terminator answer
+human parsed fields
+```
+
+#### B1: OCR + LLM
+
+Allowed inputs:
+
+```text
+full-chart OCR text
+OCR bbox / confidence only if the prompt explicitly declares their use
+B1 prompt
+```
+
+Forbidden inputs:
+
+```text
+chart image
+gold_ma_prose
+canonical target
+expected value
+field-to-leg target mapping
+evidence provenance
+challenge tags
+human parsed fields
+Q_terminator answer
+```
+
+#### C3: image -> questionnaire -> canonical JSON
+
+Allowed inputs:
+
+```text
+full chart image
+frozen questionnaire prompt / template
+```
+
+Forbidden inputs:
+
+```text
+OCR text
+gold_ma_prose
+canonical target
+expected value
+field-to-leg target mapping
+evidence provenance
+challenge tags
+human parsed fields
+Q_terminator answer
+```
+
+### 2.3 Prompt 通用规则
+
+所有 LLM/VLM prompt 必须显式允许：
+
+```text
+unknown
+not_observable
+图上看不出
+无法判断
+```
+
+Prompt 不得强迫模型在无证据时硬选具体值。
+
+每个 prompt 必须记录：
+
+```text
+prompt_path
+prompt_hash
+prompt_source
+method_id
+run_id
+created_at
+inherits_issue_20 = true / false
+```
+
+如果 prompt 内容发生变化：
+
+```text
+must generate a new prompt_hash
+must generate a new run_id
+must not overwrite previous results
+```
+
+### 2.4 Parser repair 通用规则
+
+Allowed repair:
+
+```text
+remove markdown code fence
+extract the first JSON object
+remove explanatory text before/after JSON
+normalize field-name casing
+normalize unknown / not observable / cannot determine to schema vocabulary
+mark invalid according to schema, instead of filling answers
+```
+
+Forbidden repair:
+
+```text
+modify field values using canonical target
+repair JSON using scorer result
+manually fill Q_terminator
+manually add missing legs
+manually fill altitude / fix / turn / hold values
+delete failed samples
+change wrong answers to unknown
+```
+
+Parse failure handling:
+
+```text
+keep raw output
+record parse_error
+mark final output invalid
+include invalid output in scorer statistics
+never silently drop samples
+```
+
+Parser policy version for this pilot:
+
+```text
+parser_repair_policy_v0
+```
+
+### 2.5 Run manifest / output structure 通用规则
+
+Each run must save:
+
+```text
+input_manifest.jsonl
+run_manifest.json
+raw_outputs/
+parsed_json/
+final_canonical_json/
+prediction.jsonl
+validation_report.json
+```
+
+`run_manifest.json` must include at least:
+
+```json
+{
+  "run_id": "TBD",
+  "method_id": "A1/B1/C3",
+  "experiment_id": "pilot10_exp1_a1_b1_c3",
+  "sample_manifest": "TBD",
+  "schema_source": "TBD",
+  "target_source": "TBD",
+  "model_config_hash": "TBD",
+  "prompt_hash": "TBD",
+  "parser_policy_version": "parser_repair_policy_v0",
+  "input_policy_version": "input_policy_v0",
+  "output_path": "TBD",
+  "created_at": "TBD"
+}
+```
+
+### 2.6 Rerun policy 通用规则
+
+Allowed reruns:
+
+```text
+API timeout
+network error
+OCR process crash
+file read failure
+empty model service response
+```
+
+Reruns that must not overwrite previous results:
+
+```text
+wrong answer
+poor score
+unsatisfactory prompt
+unexpected parser behavior
+one method looks disadvantaged
+```
+
+If prompt / parser / model / OCR changes:
+
+```text
+must create a new run_id
+must preserve previous raw_outputs
+must record change reason
+must not overwrite previous prediction.jsonl
+```
+
+## 3. Pilot-specific frozen parameters
+
+本节只服务本次 10 张图试跑，不直接推广到正式 eval。
+
+### 3.1 Pilot run_id
+
+Initial run id:
+
+```text
+pilot10_exp1_a1_b1_c3_v0
+```
+
+If prompt changes:
+
+```text
+pilot10_exp1_a1_b1_c3_v1_prompt_fix
+```
+
+If parser changes:
+
+```text
+pilot10_exp1_a1_b1_c3_v2_parser_fix
+```
+
+### 3.2 Pilot10 sample manifest
+
+Sample source priority:
+
+```text
+1. formal300 外的 practice10 / pilot10 assets
+2. additionally collected FAA missed approach charts outside formal300
+3. formal300 samples only if marked excluded_from_formal_eval = true
+```
+
+Each sample record should use this shape:
+
+```json
+{
+  "chart_id": "TBD",
+  "procedure_id": "TBD",
+  "split": "pilot10_dev",
+  "source_image": "TBD",
+  "canonical_target": "TBD",
+  "selection_reason": "ordinary / holding / ca_leg / multi_leg / ocr_hard / path_terminator_hard",
+  "excluded_from_formal_eval": true,
+  "source_ref": "TBD"
+}
+```
+
+Pilot10 sample manifest path:
+
+```text
+benchmark_exports/derived/v2/pilot10_manifest.jsonl
+```
+
+### 3.3 Pilot schema / questionnaire / target source
+
+Expected frozen sources for this pilot:
+
+```text
+schema_source:
+  PR #28
+  commit: d2c54172b31184f8c0deb74415f37c239d3e3eca
+  path: schemas/missed_approach_leg.schema.json
+
+questionnaire_source:
+  PR #28
+  commit: d2c54172b31184f8c0deb74415f37c239d3e3eca
+  path: prompts/path_e_v2/structured_form_template.txt
+
+target_source:
+  PR #32 or practice10 / formal300 target path
+  commit: d606b747a1cda86a013df1f145de2a1fa17e176d
+
+cifp_pipeline_provenance:
+  PR #29
+  commit: 1930aa381955ed1c2001d62dd9dae797d2fddc68
+```
+
+If a different commit/path is used, update this section before running the pilot.
+
+### 3.4 Pilot OCR / LLM / VLM parameters
+
+```json
+{
+  "run_id": "pilot10_exp1_a1_b1_c3_v0",
+  "ocr": {
+    "applies_to": ["A1", "B1"],
+    "engine": "TBD",
+    "version": "TBD",
+    "settings": "TBD"
+  },
+  "llm": {
+    "applies_to": ["B1"],
+    "model": "TBD",
+    "temperature": 0,
+    "top_p": 1,
+    "max_tokens": "TBD"
+  },
+  "vlm": {
+    "applies_to": ["C3"],
+    "model": "TBD",
+    "temperature": 0,
+    "top_p": 1,
+    "max_tokens": "TBD",
+    "image_resolution_policy": "TBD"
+  }
+}
+```
+
+The pilot should not run until all `TBD` fields required for the selected methods are filled.
+
+### 3.5 Pilot prompt paths and hashes
+
+Recommended prompt paths:
+
+```text
+prompts/paper_v2/b1_ocr_to_canonical_pilot10.md
+prompts/paper_v2/c3_questionnaire_pilot10.md
+```
+
+Prompt manifest shape:
+
+```json
+[
+  {
+    "method_id": "B1",
+    "prompt_path": "prompts/paper_v2/b1_ocr_to_canonical_pilot10.md",
+    "prompt_hash": "TBD",
+    "inherits": ["issue #20 unknown/not_observable instruction"]
+  },
+  {
+    "method_id": "C3",
+    "prompt_path": "prompts/paper_v2/c3_questionnaire_pilot10.md",
+    "prompt_hash": "TBD",
+    "inherits": ["PR #28 structured questionnaire", "issue #20 unknown/not_observable instruction"]
+  }
+]
+```
+
+### 3.6 Pilot output paths
+
+```text
+predictions/paper_v2/pilot10_exp1_a1_b1_c3_v0/A1/
+predictions/paper_v2/pilot10_exp1_a1_b1_c3_v0/B1/
+predictions/paper_v2/pilot10_exp1_a1_b1_c3_v0/C3/
+
+reports/paper_v2/pilot10_exp1_a1_b1_c3_v0/
+```
+
+Each method directory should contain:
+
+```text
+input_manifest.jsonl
+run_manifest.json
+raw_outputs/
+parsed_json/
+final_canonical_json/
+prediction.jsonl
+validation_report.json
+```
+
+Report directory should contain:
+
+```text
+pilot10_summary.md
+parse_error_report.json
+no_leakage_report.json
+pilot10_metrics.csv
+```
+
+## 4. Pilot success criteria
+
+Pilot success is pipeline stability, not high score.
+
+Success criteria:
+
+```text
+10 samples enter A1/B1/C3 runners
+all methods produce input_manifest
+all methods preserve raw_outputs
+all methods produce parsed_json or invalid records
+final_canonical_json can enter validator/scorer
+parse failures are not silently dropped
+no-leakage checks pass
+A1/B1/C3 can be summarized in one pilot table
+observed issues can be attributed to OCR / prompt / parser / schema / scorer / input packing
+```
+
+Not success criteria:
+
+```text
+B1 high score
+C3 high score
+A1 exceeding a threshold
+claiming one method is significantly better on pilot10
+```
+
+## 5. Pilot to formal freeze promotion rules
+
+If pilot passes, the following can be promoted to formal common policy:
+
+```text
+schema/scorer policy
+allowed/forbidden input policy
+prompt unknown/not_observable policy
+parser repair policy
+run manifest/output policy
+rerun policy
+```
+
+The following must not be directly promoted to formal eval:
+
+```text
+pilot10 sample IDs
+pilot run_id
+pilot prompt hash
+pilot output paths
+pilot result tables
+```
+
+If pilot causes changes to any of the following:
+
+```text
+schema
+prompt
+parser
+scorer
+input policy
+```
+
+then formal evaluation must:
+
+```text
+bump policy version
+record change reason
+freeze formal eval configuration again
+rerun from frozen formal eval inputs
+```
+
+## 6. Summary
+
+This pilot freeze separates reusable paper-v2 common policy from pilot-specific parameters. The common rules are designed to satisfy the experiment plan's requirements for canonical schema, no-leakage, parser handling, run traceability, and rerun discipline. The pilot-specific parameters are only for the 10-chart feasibility run and must not be treated as formal evaluation settings.

--- a/metadata/paper_v2/README.md
+++ b/metadata/paper_v2/README.md
@@ -1,0 +1,13 @@
+# paper-v2 metadata namespace
+
+This directory stores machine-readable and release-facing metadata for the NeurIPS 2026 E&D paper-v2 artifact package.
+
+## Planned files
+
+- `croissant.json` — Croissant metadata for the benchmark artifact.
+- `artifact_manifest.json` — release/package manifest linking data, code, reports, and documentation.
+
+## Related issues
+
+- PV2-17: #50
+- PV2-18: #51

--- a/predictions/paper_v2/.gitkeep
+++ b/predictions/paper_v2/.gitkeep
@@ -1,0 +1,9 @@
+# Placeholder for paper-v2 predictions.
+
+Formal prediction outputs should be organized by experiment and method, for example:
+
+- `exp1/{method_id}/`
+- `exp4_source_ablation/{view_type}/{method_id}/`
+- `exp5_oracle/{method_id}/`
+- `exp6_verification/{method_id}/`
+- `exp7_domain_rule/{method_id}/`

--- a/predictions/paper_v2/pilot10_exp1_a1_b1_c3_v0/A1/.gitkeep
+++ b/predictions/paper_v2/pilot10_exp1_a1_b1_c3_v0/A1/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for A1 pilot outputs.

--- a/predictions/paper_v2/pilot10_exp1_a1_b1_c3_v0/B1/.gitkeep
+++ b/predictions/paper_v2/pilot10_exp1_a1_b1_c3_v0/B1/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for B1 pilot outputs.

--- a/predictions/paper_v2/pilot10_exp1_a1_b1_c3_v0/C3/.gitkeep
+++ b/predictions/paper_v2/pilot10_exp1_a1_b1_c3_v0/C3/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for C3 pilot outputs.

--- a/prompts/paper_v2/b1_ocr_to_canonical_pilot10.md
+++ b/prompts/paper_v2/b1_ocr_to_canonical_pilot10.md
@@ -1,0 +1,23 @@
+# B1 Pilot Prompt: OCR Text to Canonical Missed Approach JSON
+
+Scope: `pilot10_exp1_a1_b1_c3_v0`
+
+You are given OCR text extracted from one FAA approach chart. Your task is to extract the missed-approach procedure into the project canonical JSON schema.
+
+Use only the OCR text provided in the input. Do not assume access to the chart image, canonical target, gold text, evidence labels, challenge tags, or expected values.
+
+If a field cannot be determined from the OCR text, use `unknown`. If the requested field is not applicable to the leg, use `not_applicable`. If the field is not observable from the provided input, use `not_observable`. Do not guess when evidence is missing.
+
+Return only JSON. Do not include markdown fences or explanation.
+
+## Required output shape
+
+TBD: replace with the exact schema excerpt or reference once the pilot schema source is pinned.
+
+## Input
+
+OCR text:
+
+```text
+{{OCR_TEXT}}
+```

--- a/prompts/paper_v2/c3_questionnaire_pilot10.md
+++ b/prompts/paper_v2/c3_questionnaire_pilot10.md
@@ -1,0 +1,19 @@
+# C3 Pilot Prompt: Full Chart Image to Questionnaire-Structured Canonical JSON
+
+Scope: `pilot10_exp1_a1_b1_c3_v0`
+
+You are given one FAA approach chart image. Fill the missed-approach questionnaire and return canonical JSON according to the paper-v2 schema.
+
+Use only the chart image and this questionnaire prompt. Do not use OCR text, gold text, canonical targets, evidence labels, challenge tags, or expected values.
+
+If a field cannot be determined from the chart, use `unknown`. If a field is not applicable to the leg, use `not_applicable`. If a field is not observable from the chart evidence, use `not_observable`. Do not guess when evidence is missing.
+
+Return only JSON. Do not include markdown fences or explanation.
+
+## Questionnaire
+
+TBD: paste or reference the frozen PR #28 structured questionnaire template once schema source is pinned.
+
+## Image input
+
+{{CHART_IMAGE}}

--- a/reports/paper_v2/README.md
+++ b/reports/paper_v2/README.md
@@ -1,0 +1,28 @@
+# paper-v2 report namespace
+
+This directory stores paper-v2 reports, quality-control summaries, and paper-ready tables.
+
+Reports here should be generated from frozen predictions, scorers, and manifests. Avoid hand-editing table values; if a table must be manually curated for the paper, keep the generated source table next to it.
+
+## Planned reports
+
+- `paper_tables/` — main paper tables.
+- `appendix_tables/` — full matrices and appendix tables.
+- `no_leakage_report.json` — input-packer leakage validation.
+- `annotation_reliability_report.md` — annotation reliability and adjudication summary.
+- `bootstrap_ci.csv` — point estimates and bootstrap CIs.
+- `paired_delta_ci.csv` — paired method/view deltas.
+- `source_ablation_report.md` — source-view ablation interpretation.
+- `counterfactual_qc_report.md` — chart-to-424 counterfactual QC.
+
+## Related issues
+
+- PV2-08: #41
+- PV2-09: #42
+- PV2-10: #43
+- PV2-11: #44
+- PV2-12: #45
+- PV2-14: #47
+- PV2-15: #48
+- PV2-16: #49
+- PV2-18: #51

--- a/reports/paper_v2/appendix_tables/.gitkeep
+++ b/reports/paper_v2/appendix_tables/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for paper-v2 appendix tables.

--- a/reports/paper_v2/paper_tables/.gitkeep
+++ b/reports/paper_v2/paper_tables/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for paper-v2 main paper tables.

--- a/reports/paper_v2/pilot10_exp1_a1_b1_c3_v0/.gitkeep
+++ b/reports/paper_v2/pilot10_exp1_a1_b1_c3_v0/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for pilot10 A1/B1/C3 reports.

--- a/scripts/paper_v2/README.md
+++ b/scripts/paper_v2/README.md
@@ -1,0 +1,27 @@
+# paper-v2 script namespace
+
+This directory is reserved for paper-v2 scripts. Scripts here should read from frozen paper-v2 manifests and write to paper-v2 prediction/report directories.
+
+Do not modify legacy `data/`, `results/`, or first-round ABCDE outputs in paper-v2 scripts unless an issue explicitly authorizes that migration.
+
+## Planned scripts
+
+- `build_v2_export.py` — materialize `benchmark_exports/derived/v2/` from existing repo assets.
+- `build_source_views.py` — generate source-view images and masks.
+- `validate_no_leakage.py` — validate input manifests against forbidden fields.
+- `build_424_counterfactuals.py` — generate chart-to-424 verification cases.
+- `score_extraction.py` — score canonical extraction outputs.
+- `score_by_evidence_source.py` — compute evidence-bucket breakdowns.
+- `score_by_challenge_tags.py` — compute challenge split metrics.
+- `bootstrap_metrics.py` — chart/procedure-level bootstrap CIs.
+- `paired_delta_ci.py` — paired method/source-view deltas.
+
+## Related issues
+
+- PV2-04: #37
+- PV2-07: #40
+- PV2-09: #42
+- PV2-10: #43
+- PV2-12: #45
+- PV2-14: #47
+- PV2-16: #49


### PR DESCRIPTION
## Summary

Adds a dedicated paper-v2 namespace for the NeurIPS 2026 Evaluations & Datasets submission workflow.

This PR only creates scaffold directories and lightweight README/placeholders. It does not modify existing formal100/formal300 data, ABCDE code paths, pilot results, scorer behavior, prompts, or published metrics.

## Added namespaces

- `docs/paper_v2/`
- `configs/paper_v2/`
- `scripts/paper_v2/`
- `benchmark_exports/derived/v2/`
- `predictions/paper_v2/`
- `reports/paper_v2/`
- `reports/paper_v2/paper_tables/`
- `reports/paper_v2/appendix_tables/`
- `metadata/paper_v2/`

## Related paper-v2 issues

- Parent epic: #33
- Freeze layer: #34, #35, #36
- Data/input layer: #37, #38, #39, #40
- Experiment layer: #41, #42, #43, #44, #45, #46
- QC/artifact layer: #47, #48, #49, #50, #51

## Reproducibility Impact

- [x] no impact on existing formal100 / formal300 splits
- [x] no committed data or result files changed
- [x] docs/scaffold only

## Validation

- Not run; scaffold-only change.

## Next steps after merge

1. Fill `docs/paper_v2/experiment_registry.md` and related freeze documents for PV2-01.
2. Lock paper-v2 split and sample manifests for PV2-02.
3. Freeze method, model, prompt, parser, and rerun manifests for PV2-03.
4. Build `benchmark_exports/derived/v2/MANIFEST.json` for PV2-04.
5. Implement no-leakage policy and validator skeleton for PV2-14 before running evaluation.